### PR TITLE
Workaround PV types not flowing

### DIFF
--- a/server/endpoints.ts
+++ b/server/endpoints.ts
@@ -29,7 +29,7 @@ export default {
 			}),
 			route_param_validator: pv({
 				invoice_uuid: pv.string,
-			}),
+			})(),
 			async fn({ mysql, body, route_params }) {
 				await mysql.execute(sql`
 					UPDATE invoice_anonymous

--- a/server/util/param_validator.ts
+++ b/server/util/param_validator.ts
@@ -157,14 +157,14 @@ type MakeValidator = {
 	>(
 		shape: CastShape<DESIRED_OBJECT>,
 		options?: { throw_on_invalid_optional_values?: boolean; allow_non_specified_values?: false },
-	): (object: INPUT) => UndefinedActuallyMeansOptional<DESIRED_OBJECT>
+	): () => (object: INPUT) => UndefinedActuallyMeansOptional<DESIRED_OBJECT>
 	<
 		DESIRED_OBJECT extends { [key: string]: any },
 		INPUT extends Partial<{ [key in keyof DESIRED_OBJECT]: string | string[] }>,
 	>(
 		shape: CastShape<DESIRED_OBJECT>,
 		options: { throw_on_invalid_optional_values?: boolean; allow_non_specified_values: true },
-	): <ACTUAL_INPUT extends INPUT & { [key: string]: string }>(
+	): () => <ACTUAL_INPUT extends INPUT & { [key: string]: string }>(
 		object: ACTUAL_INPUT,
 	) => UndefinedActuallyMeansOptional<
 		DESIRED_OBJECT & { [key in Exclude<keyof ACTUAL_INPUT, keyof INPUT>]: string }
@@ -179,7 +179,7 @@ const make_validator: MakeValidator = <
 }: { throw_on_invalid_optional_values?: boolean; allow_non_specified_values?: boolean } = {}) => {
 	const officially_accepted_keys = Object.keys(shape)
 
-	return (
+	return () => (
 		object: Partial<{ [key in keyof DESIRED_OBJECT]: string | string[] }>,
 	): UndefinedActuallyMeansOptional<DESIRED_OBJECT> => {
 		const validated_output_object = from_entries(

--- a/server/util/param_validator.ts
+++ b/server/util/param_validator.ts
@@ -157,14 +157,14 @@ type MakeValidator = {
 	>(
 		shape: CastShape<DESIRED_OBJECT>,
 		options?: { throw_on_invalid_optional_values?: boolean; allow_non_specified_values?: false },
-	): () => (object: INPUT) => UndefinedActuallyMeansOptional<DESIRED_OBJECT>
+	): (...args: never[]) => (object: INPUT) => UndefinedActuallyMeansOptional<DESIRED_OBJECT>
 	<
 		DESIRED_OBJECT extends { [key: string]: any },
 		INPUT extends Partial<{ [key in keyof DESIRED_OBJECT]: string | string[] }>,
 	>(
 		shape: CastShape<DESIRED_OBJECT>,
 		options: { throw_on_invalid_optional_values?: boolean; allow_non_specified_values: true },
-	): () => <ACTUAL_INPUT extends INPUT & { [key: string]: string }>(
+	): (...args: never[]) => <ACTUAL_INPUT extends INPUT & { [key: string]: string }>(
 		object: ACTUAL_INPUT,
 	) => UndefinedActuallyMeansOptional<
 		DESIRED_OBJECT & { [key in Exclude<keyof ACTUAL_INPUT, keyof INPUT>]: string }


### PR DESCRIPTION
I don't love this solution, and it does mess with the syntax.

```diff
export const endpoint = force_endpoint_type({
-	query_param_validator: pv({ some_num: integer }),   // BEFORE
+	query_param_validator: pv({ some_num: integer })(), // AFTER
	fn: (context) => {
		context.query_params.some_num
		// @ts-expect-error
		context.query_params.does_not_exist
	},
})
```

Up to you...

![image](https://github.com/TehShrike/photoquoter/assets/1833684/5f9603fa-6ba9-4e76-841e-c97dfdd617af)


